### PR TITLE
Fixed Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 ### Rules
 
 - Only single files per "useless feature"
-- Don't break TOS
+- Break TOS


### PR DESCRIPTION
There was a typo on the second rule of your README. This PR fixes that.